### PR TITLE
feat!: implement per-request API key authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Desktop.ini
 *.old
 tmp/
 temp/
+release_notes/
 
 # Database
 *.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-10-04
+
+### Changed
+
+- **BREAKING**: Refactored authentication architecture to pass OpenAI API key per-request instead of at server startup
+- `phone_a_friend` now requires `api_key` parameter and accepts optional `model` and `max_tokens` parameters
+- `review_plan` now requires `api_key` parameter and accepts optional `model` and `max_tokens` parameters
+- `health_check` no longer returns `openai_configured` field
+- Updated README with comprehensive documentation of new per-request authentication flow
+- Updated MCP client configuration examples to reflect API key passing from client
+
+### Removed
+
+- Removed `OPENAI_API_KEY`, `OPENAI_MODEL`, and `OPENAI_MAX_TOKENS` from Docker environment variables
+- Removed global OpenAI client initialization at server startup
+- Removed API key requirement from `.env.example` file
+- Removed `OPENAI_*` environment variables from `fastmcp.json` deployment configuration
+
+### Security
+
+- **Improved**: API keys are no longer stored in Docker containers or environment files
+- **Improved**: Per-request authentication allows different MCP clients to use different API keys
+- **Improved**: API key management handled securely by MCP client configuration
+- **Improved**: Server no longer requires access to OpenAI credentials at startup
+
+### Fixed
+
+- Server now starts successfully without requiring OpenAI API key configuration
+- Cleaned up unused imports (`asyncio`, `os`) from server.py
+
 ## [0.1.0] - 2025-10-04
 
 ### Added
@@ -22,4 +52,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration for pip and GitHub Actions
 - Smoke test script (`scripts/smoke.sh`) for health endpoint validation
 
+[0.1.1]: https://github.com/bernierllc/brain-trust-mcp/releases/tag/v0.1.1
 [0.1.0]: https://github.com/bernierllc/brain-trust-mcp/releases/tag/v0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   mcp-server:
@@ -6,9 +6,6 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4}
-      - OPENAI_MAX_TOKENS=${OPENAI_MAX_TOKENS:-1000}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     volumes:
       - ./logs:/app/logs

--- a/env.example
+++ b/env.example
@@ -1,11 +1,10 @@
-# OpenAI Configuration
-OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4
-OPENAI_MAX_TOKENS=1000
-
 # Server Configuration
 LOG_LEVEL=INFO
 PORT=8000
+
+# Note: OpenAI API key is no longer required as an environment variable.
+# The API key is passed directly by the MCP client with each tool call.
+# Configure the API key in your MCP client settings (e.g., Cursor's MCP configuration).
 
 # Optional: Database Configuration (for future use)
 # DATABASE_URL=postgresql://user:password@localhost:5432/mcp_db

--- a/fastmcp.json
+++ b/fastmcp.json
@@ -24,9 +24,6 @@
     "path": "/mcp",
     "log_level": "INFO",
     "env": {
-      "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-      "OPENAI_MODEL": "${OPENAI_MODEL}",
-      "OPENAI_MAX_TOKENS": "${OPENAI_MAX_TOKENS}",
       "LOG_LEVEL": "${LOG_LEVEL}"
     },
     "cwd": "/app"

--- a/server.py
+++ b/server.py
@@ -3,9 +3,7 @@
 Contextual Q&A MCP Server with OpenAI integration and plan review capabilities.
 """
 
-import asyncio
 import json
-import os
 from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional
@@ -39,18 +37,8 @@ logger = structlog.get_logger()
 # Initialize FastMCP server
 mcp = FastMCP("brain-trust")
 
-# Configure OpenAI client
-openai_client = None
+# Note: OpenAI client is created per-request with API key from tool parameters
 
-def initialize_openai():
-    """Initialize OpenAI client with API key from environment."""
-    global openai_client
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY environment variable is required")
-
-    openai_client = openai.OpenAI(api_key=api_key)
-    logger.info("OpenAI client initialized successfully")
 
 # Data Models
 class ReviewLevel(str, Enum):
@@ -59,6 +47,7 @@ class ReviewLevel(str, Enum):
     STANDARD = "standard"     # Detailed analysis with suggestions
     COMPREHENSIVE = "comprehensive"  # Deep analysis with alternatives
     EXPERT = "expert"         # Professional-level review with best practices
+
 
 class PlanReview(BaseModel):
     """Plan review result."""
@@ -71,18 +60,23 @@ class PlanReview(BaseModel):
     detailed_feedback: str
     reviewed_at: datetime = Field(default_factory=datetime.now)
 
+
 # In-memory storage for plan reviews
 plan_reviews: Dict[str, PlanReview] = {}
+
 
 # OpenAI Integration Tools
 @mcp.tool()
 async def phone_a_friend(
     question: Annotated[str, "The question to ask OpenAI"],
-    context: Annotated[Optional[str], "Optional context information to provide background for the question"] = None
+    api_key: Annotated[str, "OpenAI API key for authentication"],
+    context: Annotated[Optional[str], "Optional context information to provide background for the question"] = None,
+    model: Annotated[str, "OpenAI model to use"] = "gpt-4",
+    max_tokens: Annotated[int, "Maximum tokens for response"] = 1000
 ) -> str:
     """Phone a friend (OpenAI) to get help with a question."""
-    if not openai_client:
-        initialize_openai()
+    # Create OpenAI client with provided API key
+    client = openai.OpenAI(api_key=api_key)
 
     # Build prompt with optional context
     if context:
@@ -91,10 +85,10 @@ async def phone_a_friend(
         prompt = f"Question: {question}\n\nPlease provide a comprehensive answer."
 
     try:
-        response = openai_client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-4"),
+        response = client.chat.completions.create(
+            model=model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=int(os.getenv("OPENAI_MAX_TOKENS", "1000")),
+            max_tokens=max_tokens,
             temperature=0.3
         )
 
@@ -107,29 +101,37 @@ async def phone_a_friend(
         logger.error("Failed to phone a friend", error=str(e))
         raise
 
+
 # Plan Review Tool
 @mcp.tool()
 async def review_plan(
     plan_content: Annotated[str, "The full content of the plan document to review"],
+    api_key: Annotated[str, "OpenAI API key for authentication"],
     review_level: Annotated[ReviewLevel, "Level of review depth: 'quick', 'standard', 'comprehensive', or 'expert'"] = ReviewLevel.STANDARD,
     context: Annotated[Optional[str], "Optional context information about the project, team, or constraints"] = None,
     plan_id: Annotated[Optional[str], "Optional identifier for the plan"] = None,
-    focus_areas: Annotated[Optional[List[str]], "Specific areas to focus on (e.g., 'timeline', 'resources', 'risks', 'budget', 'stakeholders')"] = None
+    focus_areas: Annotated[Optional[List[str]], "Specific areas to focus on (e.g., 'timeline', 'resources', 'risks', 'budget', 'stakeholders')"] = None,
+    model: Annotated[str, "OpenAI model to use"] = "gpt-4",
+    max_tokens: Annotated[int, "Maximum tokens for response"] = 2000
 ) -> Dict[str, Any]:
     """
     Review a plan file and provide feedback based on the specified review level.
 
     Args:
         plan_content: The content of the plan file to review
+        api_key: OpenAI API key for authentication
         review_level: Level of review depth (quick, standard, comprehensive, expert)
+        context: Optional context information about the project, team, or constraints
         plan_id: Optional identifier for the plan
         focus_areas: Optional list of specific areas to focus the review on
+        model: OpenAI model to use (default: gpt-4)
+        max_tokens: Maximum tokens for response (default: 2000)
 
     Returns:
         Dictionary containing review results and feedback
     """
-    if not openai_client:
-        initialize_openai()
+    # Create OpenAI client with provided API key
+    client = openai.OpenAI(api_key=api_key)
 
     # Generate plan ID if not provided
     if not plan_id:
@@ -210,10 +212,10 @@ async def review_plan(
     """
 
     try:
-        response = openai_client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-4"),
+        response = client.chat.completions.create(
+            model=model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=int(os.getenv("OPENAI_MAX_TOKENS", "2000")),
+            max_tokens=max_tokens,
             temperature=0.3
         )
 
@@ -278,6 +280,7 @@ async def review_plan(
         logger.error("Failed to review plan", error=str(e), plan_id=plan_id)
         raise
 
+
 # Health check endpoint
 @mcp.tool()
 async def health_check() -> Dict[str, Any]:
@@ -285,16 +288,11 @@ async def health_check() -> Dict[str, Any]:
     return {
         "status": "healthy",
         "timestamp": datetime.now().isoformat(),
-        "openai_configured": openai_client is not None,
         "plan_reviews_count": len(plan_reviews)
     }
 
-# Initialize OpenAI on startup
-try:
-    initialize_openai()
-    logger.info("MCP server initialized successfully")
-except Exception as e:
-    logger.error("Failed to initialize MCP server", error=str(e))
+# Server startup logging
+logger.info("MCP server initialized successfully")
 
 if __name__ == "__main__":
     # Run the server


### PR DESCRIPTION
BREAKING CHANGE: Refactored authentication architecture to pass OpenAI API key per-request instead of at server startup.

Changes:
- phone_a_friend now requires api_key parameter and accepts optional model and max_tokens parameters
- review_plan now requires api_key parameter and accepts optional model and max_tokens parameters
- health_check no longer returns openai_configured field
- Removed OPENAI_API_KEY, OPENAI_MODEL, and OPENAI_MAX_TOKENS from Docker environment variables
- Removed global OpenAI client initialization at server startup
- Updated README with comprehensive documentation of new authentication flow
- Updated MCP client configuration examples

Security improvements:
- API keys no longer stored in Docker containers or environment files
- Per-request authentication allows different MCP clients to use different API keys
- API key management handled securely by MCP client configuration
- Server no longer requires access to OpenAI credentials at startup

Fixes:
- Server now starts successfully without requiring OpenAI API key
- Cleaned up unused imports (asyncio, os) from server.py

## Description

Please include a summary of the changes and the related issue. Link to the issue if applicable.

## Type of change

- [x] feat: New feature / security fix
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code refactor
- [ ] chore: Maintenance
- [ ] test: Tests added/updated

## How Has This Been Tested?

Works on my machine

## Checklist

- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have added/updated necessary documentation
- [ ] I have updated CHANGELOG.md if applicable
- [ ] I have run formatting and linting (black, isort, flake8, pylint)

## Screenshots (if applicable)
